### PR TITLE
fix full path not exists

### DIFF
--- a/cgroup/reader.go
+++ b/cgroup/reader.go
@@ -120,12 +120,16 @@ func (r *Reader) GetStatsForProcess(pid int) (*Stats, error) {
 		if r.cgroupsHierarchyOverride != "" {
 			path = r.cgroupsHierarchyOverride
 		}
+		fullPath := filepath.Join(subsystemMount, path)
+		if !Exists(fullPath) {
+			fullPath = subsystemMount
+		}
 		mounts[interestedSubsystem] = mount{
 			subsystem:  interestedSubsystem,
 			mountpoint: subsystemMount,
 			id:         id,
 			path:       path,
-			fullPath:   filepath.Join(subsystemMount, path),
+			fullPath:   fullPath,
 		}
 	}
 

--- a/cgroup/util.go
+++ b/cgroup/util.go
@@ -261,3 +261,14 @@ func ProcessCgroupPaths(rootfsMountpoint string, pid int) (map[string]string, er
 
 	return paths, sc.Err()
 }
+
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsExist(err) {
+			return true
+		}
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
In k8s's pod container, the full path which is end with container info does not exists. So we just use the mount subsystem mount path instead.